### PR TITLE
buildkite: support GitHub Enterprise settings

### DIFF
--- a/buildkite/providers.go
+++ b/buildkite/providers.go
@@ -27,7 +27,10 @@ func (p *Provider) UnmarshalJSON(data []byte) error {
 	switch v.ID {
 	case "bitbucket":
 		settings = &BitbucketSettings{}
-	case "github":
+	case "github", "github_enterprise":
+		// TODO(stevvooe): Not sure if we have the same settings between GitHub
+		// and GitHub Enterprise but this should unblock simple use cases for
+		// now.
 		settings = &GitHubSettings{}
 	case "gitlab":
 		settings = &GitLabSettings{}


### PR DESCRIPTION
This change adds "github_enterprise" to the switch when resolving the 
settings type during unmarshaling. I'm not sure if we have the same 
settings between GitHub and GitHub Enterprise but this should unblock 
simple use cases for now.